### PR TITLE
fix: dnd5e mapping improvements

### DIFF
--- a/mappings/dnd5e.mapping
+++ b/mappings/dnd5e.mapping
@@ -14,13 +14,13 @@
     { "pdf": "AC", "foundry": @data.attributes.ac.value },
     { "pdf": "Initiative", "foundry": @data.attributes.init.total },
     { "pdf": "Speed", "foundry": Object.entries(@data.attributes.movement).filter(val => val[1]).map(val => val[0] === "hover" ? Object.entries(@data.attributes.movement)[6][0] : "" + val[0] !== "units" && val[0] !== "hover" ? val.join(": ") + Object.entries(@data.attributes.movement)[5][1] : "").filter(String).join(", ") },
-    { "pdf": "PersonalityTraits", "foundry": @data.details.trait },
+    { "pdf": "PersonalityTraits", "foundry": @data.details.trait?.replaceAll(/<[^>]*>/g, "").replaceAll(/&[^;];/g, "").trim() },
     { "pdf": "STRmod", "foundry": @data.abilities.str.mod },
     { "pdf": "ST Strength", "foundry": @data.abilities.str.save },
     { "pdf": "DEX", "foundry": @data.abilities.dex.value },
-    { "pdf": "Ideals", "foundry": @data.details.ideal },
+    { "pdf": "Ideals", "foundry": @data.details.ideal?.replaceAll(/<[^>]*>/g, "").replaceAll(/&[^;];/g, "").trim() },
     { "pdf": "DEXmod", "foundry": @data.abilities.dex.mod },
-    { "pdf": "Bonds", "foundry": @data.details.bond },
+    { "pdf": "Bonds", "foundry": @data.details.bond?.replaceAll(/<[^>]*>/g, "").replaceAll(/&[^;];/g, "").trim() },
     { "pdf": "CON", "foundry": @data.abilities.con.value },
     { "pdf": "HDTotal", "foundry": @data.attributes.hd },
     { "pdf": "Check Box 12", "foundry": @data.attributes.death.success },
@@ -31,7 +31,7 @@
     { "pdf": "Check Box 16", "foundry": @data.attributes.death.failure },
     { "pdf": "Check Box 17", "foundry": @data.attributes.death.failure },
     { "pdf": "HD", "foundry": @data.attributes.hd },
-    { "pdf": "Flaws", "foundry": @data.details.flaw },
+    { "pdf": "Flaws", "foundry": @data.details.flaw?.replaceAll(/<[^>]*>/g, "").replaceAll(/&[^;];/g, "").trim() },
     { "pdf": "INT", "foundry": @data.abilities.int.value },
     { "pdf": "ST Dexterity", "foundry": @data.abilities.dex.save },
     { "pdf": "ST Constitution", "foundry": @data.abilities.con.save },
@@ -44,14 +44,14 @@
     { "pdf": "Deception", "foundry": @data.skills.dec.total },
     { "pdf": "History", "foundry": @data.skills.his.total },
     { "pdf": "Wpn Name", "foundry": @items.filter(i => i.type === 'weapon' && i.data.data.equipped && i.hasAttack && i.hasDamage)[0]?.name || "" },
-    { "pdf": "Wpn1 AtkBonus", "foundry": "" },
-    { "pdf": "Wpn1 Damage", "foundry": @items.filter(i => i.type === 'weapon' && i.data.data.equipped && i.hasAttack && i.hasDamage)[0]?.data?.data?.damage?.parts[0][0] || "" },
+    { "pdf": "Wpn1 AtkBonus", "foundry": @items.filter(i => i.type === 'weapon' && i.data.data.equipped && i.hasAttack && i.hasDamage)[0]?.labels.toHit || "" },
+    { "pdf": "Wpn1 Damage", "foundry": (function() { let dda = Array.from(actor.items.filter(i => i.type === 'weapon' && i.data.data.equipped && i.hasAttack && i.hasDamage))[0]?.labels.derivedDamage; return dda[0].formula + (dda?.length > 1 ? " *" : "")})() },
     { "pdf": "Insight", "foundry": @data.skills.ins.total },
     { "pdf": "Intimidation", "foundry": @data.skills.itm.total },
     { "pdf": "Wpn Name 2", "foundry": @items.filter(i => i.type === 'weapon' && i.data.data.equipped && i.hasAttack && i.hasDamage)[1]?.name || "" },
-    { "pdf": "Wpn2 AtkBonus", "foundry": "" },
+    { "pdf": "Wpn2 AtkBonus", "foundry": @items.filter(i => i.type === 'weapon' && i.data.data.equipped && i.hasAttack && i.hasDamage)[1]?.labels.toHit || "" },
     { "pdf": "Wpn Name 3", "foundry": @items.filter(i => i.type === 'weapon' && i.data.data.equipped && i.hasAttack && i.hasDamage)[2]?.name || "" },
-    { "pdf": "Wpn3 AtkBonus", "foundry": "" },
+    { "pdf": "Wpn3 AtkBonus", "foundry": @items.filter(i => i.type === 'weapon' && i.data.data.equipped && i.hasAttack && i.hasDamage)[2]?.labels.toHit || "" },
     { "pdf": "Check Box 11", "foundry": @data.abilities.str.proficient },
     { "pdf": "Check Box 18", "foundry": @data.abilities.dex.proficient },
     { "pdf": "Check Box 19", "foundry": @data.abilities.con.proficient },
@@ -59,7 +59,7 @@
     { "pdf": "Check Box 21", "foundry": @data.abilities.wis.proficient },
     { "pdf": "Check Box 22", "foundry": @data.abilities.cha.proficient },
     { "pdf": "INTmod", "foundry": @data.abilities.int.mod },
-    { "pdf": "Wpn2 Damage", "foundry": @items.filter(i => i.type === 'weapon' && i.data.data.equipped && i.hasAttack && i.hasDamage)[1]?.data?.data?.damage?.parts[0][0] || "" },
+    { "pdf": "Wpn2 Damage", "foundry": (function() { let dda = Array.from(actor.items.filter(i => i.type === 'weapon' && i.data.data.equipped && i.hasAttack && i.hasDamage))[1]?.labels.derivedDamage; return dda[0].formula + (dda?.length > 1 ? " *" : "")})() },
     { "pdf": "Investigation", "foundry": @data.skills.inv.total },
     { "pdf": "WIS", "foundry": @data.abilities.wis.value },
     { "pdf": "Arcana", "foundry": @data.skills.arc.total },
@@ -93,7 +93,7 @@
     { "pdf": "HPMax", "foundry": @data.attributes.hp.max },
     { "pdf": "HPCurrent", "foundry": @data.attributes.hp.value },
     { "pdf": "HPTemp", "foundry": @data.attributes.hp.temp },
-    { "pdf": "Wpn3 Damage", "foundry": @items.filter(i => i.type === 'weapon' && i.data.data.equipped && i.hasAttack && i.hasDamage)[2]?.data?.data?.damage?.parts[0][0] || "" },
+    { "pdf": "Wpn3 Damage", "foundry": (function() { let dda = Array.from(actor.items.filter(i => i.type === 'weapon' && i.data.data.equipped && i.hasAttack && i.hasDamage))[2]?.labels.derivedDamage; return dda[0].formula + (dda?.length > 1 ? " *" : "")})()},
     { "pdf": "SleightofHand", "foundry": @data.skills.slt.total },
     { "pdf": "CHamod", "foundry": @data.abilities.cha.mod },
     { "pdf": "Survival", "foundry": @data.skills.sur.total },
@@ -102,21 +102,28 @@
     { "pdf": "CP", "foundry": @data.currency.cp },
     { "pdf": "ProficienciesLang", "foundry":
         [
-            actor.data.data.traits.languages.value.filter(String).map(l => l.capitalize()).join(", "),
-            actor.data.data.traits.languages.custom,
-            actor.data.data.traits.weaponProf.value.filter(String).map(l => l.capitalize()).join(", "),
-            actor.data.data.traits.weaponProf.custom,
-            actor.data.data.traits.toolProf.value.filter(String).map(l => l.capitalize()).join(", "),
-            actor.data.data.traits.toolProf.custom,
-            actor.data.data.traits.armorProf.value.filter(String).map(l => l.capitalize()).join(", "),
-            actor.data.data.traits.armorProf.custom,
-        ].filter(String).join(", ")
+            "Weapons: ", 
+            actor.data.data.traits.weaponProf.value.map(x => game.dnd5e.config.weaponProficiencies[x] 
+                    || game.packs.get("dnd5e.items").index.get(game.dnd5e.config.weaponIds[x])?.name)
+                .concat(actor.data.data.traits.weaponProf.custom.split(";")).filter(x => String(x) && x.length).join(", "),
+            "\nArmor: ",
+            actor.data.data.traits.armorProf.value.map(x => game.dnd5e.config.armorProficiencies[x] 
+                    || game.packs.get("dnd5e.items").index.get(game.dnd5e.config.armorIds[x])?.name)
+                .concat(actor.data.data.traits.armorProf.custom.split(";")).filter(x => String(x) && x.length).join(", "),
+            "\nTools: ",
+            actor.data.data.traits.toolProf.value.map(x => game.dnd5e.config.toolProficiencies[x] 
+                    || game.packs.get("dnd5e.items").index.get(game.dnd5e.config.toolIds[x])?.name)
+                .concat(actor.data.data.traits.toolProf.custom.split(";")).filter(x => String(x) && x.length).join(", "),
+            "\nLanguages: ",
+            actor.data.data.traits.languages.value.map(x => game.dnd5e.config.languages[x])
+                .concat(actor.data.data.traits.languages.custom.split(";")).filter(x => String(x) && x.length).join(", ")
+        ].join("")
     },
     { "pdf": "SP", "foundry": @data.currency.sp || "" },
     { "pdf": "EP", "foundry": @data.currency.ep || "" },
     { "pdf": "GP", "foundry": @data.currency.gp || "" },
-    { "pdf": "PP", "foundry": @data.currency.pp || "" },
-    { "pdf": "Equipment", "foundry": @items.filter(i => !['feat', 'class', 'weapon', 'loot'].includes(i.type)).map(i => `${i.name} (${i.data.data.quantity})`).join(', ') },
+    { "pdf": "PP", "foundry": @data.currency.pp || "" },   
+    { "pdf": "Equipment", "foundry": @items.filter(i => ['weapon', 'equipment', 'tool'].includes(i.type)).map(i => (i.data.data.quantity <= 1) ? i.name : `${i.name} (${i.data.data.quantity})`).join(', ') },
     { "pdf": "Features and Traits", "foundry": @items.filter(i => ['feat', 'trait'].includes(i.type)).slice(0, 16).map(i => `${i.name} - ${i.data.data.source}`).join('\n') },
 
     /* Page #2 */
@@ -131,9 +138,9 @@
     { "pdf": "Faction Symbol Image", "foundry": "" }, /* Images are not supported */
     { "pdf": "Allies", "foundry": "" }, /* There is no field for this on the Foundry character sheet */
     { "pdf": "FactionName", "foundry": "" }, /* There is no field for this on the Foundry character sheet */
-    { "pdf": "Backstory", "foundry": @data.details.biography.value?.replaceAll(/<[^>]*>/g, "").trim() },
+    { "pdf": "Backstory", "foundry": @data.details.biography.value?.replaceAll(/<[^>]*>/g, "").replaceAll(/&[^;];/g, "").trim() },
     { "pdf": "Feat+Traits", "foundry": @items.filter(i => ['feat', 'trait'].includes(i.type)).slice(16).map(i => `${i.name} - ${i.data.data.source}`).join('\n') },
-    { "pdf": "Treasure", "foundry": @items.filter(i => ['loot'].includes(i.type)).map(i => `${i.name} (${i.data.data.quantity})`).join(', ') },
+    { "pdf": "Treasure", "foundry": @items.filter(i => ['backpack', 'consumable', 'loot'].includes(i.type)).map(i => (i.data.data.quantity <= 1) ? i.name : `${i.name} (${i.data.data.quantity})`).join(', ') },
 
     /* Page #3 */
     { "pdf": "Spellcasting Class 2", "foundry": @items.filter(i => i.type === 'class').map(i => `${i.name}`).join(' / ') }, /* Doesn't work with multiple classes properly */

--- a/mappings/dnd5e.mapping
+++ b/mappings/dnd5e.mapping
@@ -14,13 +14,13 @@
     { "pdf": "AC", "foundry": @data.attributes.ac.value },
     { "pdf": "Initiative", "foundry": @data.attributes.init.total },
     { "pdf": "Speed", "foundry": Object.entries(@data.attributes.movement).filter(val => val[1]).map(val => val[0] === "hover" ? Object.entries(@data.attributes.movement)[6][0] : "" + val[0] !== "units" && val[0] !== "hover" ? val.join(": ") + Object.entries(@data.attributes.movement)[5][1] : "").filter(String).join(", ") },
-    { "pdf": "PersonalityTraits", "foundry": @data.details.trait?.replaceAll(/<[^>]*>/g, "").replaceAll(/&[^;];/g, "").trim() },
+    { "pdf": "PersonalityTraits", "foundry": (function(h) { let d = document.createElement("div"); d.innerHTML = h; return d.textContent || d.innerText || ""; })(@data.details.trait) },
     { "pdf": "STRmod", "foundry": @data.abilities.str.mod },
     { "pdf": "ST Strength", "foundry": @data.abilities.str.save },
     { "pdf": "DEX", "foundry": @data.abilities.dex.value },
-    { "pdf": "Ideals", "foundry": @data.details.ideal?.replaceAll(/<[^>]*>/g, "").replaceAll(/&[^;];/g, "").trim() },
+    { "pdf": "Ideals", "foundry": (function(h) { let d = document.createElement("div"); d.innerHTML = h; return d.textContent || d.innerText || ""; })(@data.details.ideal) },
     { "pdf": "DEXmod", "foundry": @data.abilities.dex.mod },
-    { "pdf": "Bonds", "foundry": @data.details.bond?.replaceAll(/<[^>]*>/g, "").replaceAll(/&[^;];/g, "").trim() },
+    { "pdf": "Bonds", "foundry": (function(h) { let d = document.createElement("div"); d.innerHTML = h; return d.textContent || d.innerText || ""; })(@data.details.bond) },
     { "pdf": "CON", "foundry": @data.abilities.con.value },
     { "pdf": "HDTotal", "foundry": @data.attributes.hd },
     { "pdf": "Check Box 12", "foundry": @data.attributes.death.success },
@@ -31,7 +31,7 @@
     { "pdf": "Check Box 16", "foundry": @data.attributes.death.failure },
     { "pdf": "Check Box 17", "foundry": @data.attributes.death.failure },
     { "pdf": "HD", "foundry": @data.attributes.hd },
-    { "pdf": "Flaws", "foundry": @data.details.flaw?.replaceAll(/<[^>]*>/g, "").replaceAll(/&[^;];/g, "").trim() },
+    { "pdf": "Flaws", "foundry": (function(h) { let d = document.createElement("div"); d.innerHTML = h; return d.textContent || d.innerText || ""; })(@data.details.flaw) },
     { "pdf": "INT", "foundry": @data.abilities.int.value },
     { "pdf": "ST Dexterity", "foundry": @data.abilities.dex.save },
     { "pdf": "ST Constitution", "foundry": @data.abilities.con.save },
@@ -44,14 +44,14 @@
     { "pdf": "Deception", "foundry": @data.skills.dec.total },
     { "pdf": "History", "foundry": @data.skills.his.total },
     { "pdf": "Wpn Name", "foundry": @items.filter(i => i.type === 'weapon' && i.data.data.equipped && i.hasAttack && i.hasDamage)[0]?.name || "" },
-    { "pdf": "Wpn1 AtkBonus", "foundry": @items.filter(i => i.type === 'weapon' && i.data.data.equipped && i.hasAttack && i.hasDamage)[0]?.labels.toHit || "" },
-    { "pdf": "Wpn1 Damage", "foundry": (function() { let dda = Array.from(actor.items.filter(i => i.type === 'weapon' && i.data.data.equipped && i.hasAttack && i.hasDamage))[0]?.labels.derivedDamage; return dda[0].formula + (dda?.length > 1 ? " *" : "")})() },
+    { "pdf": "Wpn1 AtkBonus", "foundry": @items.filter(i => i.type === 'weapon' && i.data.data.equipped && i.hasAttack && i.hasDamage)[0]?.labels.toHit.replace(/^\+ $/,"0") || "" },
+    { "pdf": "Wpn1 Damage", "foundry": (function() { let dda = Array.from(actor.itemTypes.weapon.filter(i => i.data.data.equipped && i.hasAttack && i.hasDamage))?.[0]?.labels.derivedDamage; return !dda ? "" : dda.map(dd => `${dd.formula} ${game.dnd5e.config.damageTypes[dd.damageType]}`).join('\n')})()},
     { "pdf": "Insight", "foundry": @data.skills.ins.total },
     { "pdf": "Intimidation", "foundry": @data.skills.itm.total },
     { "pdf": "Wpn Name 2", "foundry": @items.filter(i => i.type === 'weapon' && i.data.data.equipped && i.hasAttack && i.hasDamage)[1]?.name || "" },
-    { "pdf": "Wpn2 AtkBonus", "foundry": @items.filter(i => i.type === 'weapon' && i.data.data.equipped && i.hasAttack && i.hasDamage)[1]?.labels.toHit || "" },
+    { "pdf": "Wpn2 AtkBonus", "foundry": @items.filter(i => i.type === 'weapon' && i.data.data.equipped && i.hasAttack && i.hasDamage)[1]?.labels.toHit.replace(/^\+ $/,"0") || "" },
     { "pdf": "Wpn Name 3", "foundry": @items.filter(i => i.type === 'weapon' && i.data.data.equipped && i.hasAttack && i.hasDamage)[2]?.name || "" },
-    { "pdf": "Wpn3 AtkBonus", "foundry": @items.filter(i => i.type === 'weapon' && i.data.data.equipped && i.hasAttack && i.hasDamage)[2]?.labels.toHit || "" },
+    { "pdf": "Wpn3 AtkBonus", "foundry": @items.filter(i => i.type === 'weapon' && i.data.data.equipped && i.hasAttack && i.hasDamage)[2]?.labels.toHit.replace(/^\+ $/,"0") || "" },
     { "pdf": "Check Box 11", "foundry": @data.abilities.str.proficient },
     { "pdf": "Check Box 18", "foundry": @data.abilities.dex.proficient },
     { "pdf": "Check Box 19", "foundry": @data.abilities.con.proficient },
@@ -59,7 +59,7 @@
     { "pdf": "Check Box 21", "foundry": @data.abilities.wis.proficient },
     { "pdf": "Check Box 22", "foundry": @data.abilities.cha.proficient },
     { "pdf": "INTmod", "foundry": @data.abilities.int.mod },
-    { "pdf": "Wpn2 Damage", "foundry": (function() { let dda = Array.from(actor.items.filter(i => i.type === 'weapon' && i.data.data.equipped && i.hasAttack && i.hasDamage))[1]?.labels.derivedDamage; return dda[0].formula + (dda?.length > 1 ? " *" : "")})() },
+    { "pdf": "Wpn2 Damage", "foundry": (function() { let dda = Array.from(actor.itemTypes.weapon.filter(i => i.data.data.equipped && i.hasAttack && i.hasDamage))?.[1]?.labels.derivedDamage; return !dda ? "" : dda.map(dd => `${dd.formula} ${game.dnd5e.config.damageTypes[dd.damageType]}`).join('\n')})()},
     { "pdf": "Investigation", "foundry": @data.skills.inv.total },
     { "pdf": "WIS", "foundry": @data.abilities.wis.value },
     { "pdf": "Arcana", "foundry": @data.skills.arc.total },
@@ -93,31 +93,32 @@
     { "pdf": "HPMax", "foundry": @data.attributes.hp.max },
     { "pdf": "HPCurrent", "foundry": @data.attributes.hp.value },
     { "pdf": "HPTemp", "foundry": @data.attributes.hp.temp },
-    { "pdf": "Wpn3 Damage", "foundry": (function() { let dda = Array.from(actor.items.filter(i => i.type === 'weapon' && i.data.data.equipped && i.hasAttack && i.hasDamage))[2]?.labels.derivedDamage; return dda[0].formula + (dda?.length > 1 ? " *" : "")})()},
+    { "pdf": "Wpn3 Damage", "foundry": (function() { let dda = Array.from(actor.itemTypes.weapon.filter(i => i.data.data.equipped && i.hasAttack && i.hasDamage))?.[2]?.labels.derivedDamage; return !dda ? "" : dda.map(dd => `${dd.formula} ${game.dnd5e.config.damageTypes[dd.damageType]}`).join('\n')})()},
     { "pdf": "SleightofHand", "foundry": @data.skills.slt.total },
     { "pdf": "CHamod", "foundry": @data.abilities.cha.mod },
     { "pdf": "Survival", "foundry": @data.skills.sur.total },
     { "pdf": "AttacksSpellcasting", "foundry": "" },
     { "pdf": "Passive", "foundry": @data.skills.prc.passive },
-    { "pdf": "CP", "foundry": @data.currency.cp },
-    { "pdf": "ProficienciesLang", "foundry":
-        [
-            "Weapons: ", 
-            actor.data.data.traits.weaponProf.value.map(x => game.dnd5e.config.weaponProficiencies[x] 
-                    || game.packs.get("dnd5e.items").index.get(game.dnd5e.config.weaponIds[x])?.name)
-                .concat(actor.data.data.traits.weaponProf.custom.split(";")).filter(x => String(x) && x.length).join(", "),
-            "\nArmor: ",
-            actor.data.data.traits.armorProf.value.map(x => game.dnd5e.config.armorProficiencies[x] 
-                    || game.packs.get("dnd5e.items").index.get(game.dnd5e.config.armorIds[x])?.name)
-                .concat(actor.data.data.traits.armorProf.custom.split(";")).filter(x => String(x) && x.length).join(", "),
-            "\nTools: ",
-            actor.data.data.traits.toolProf.value.map(x => game.dnd5e.config.toolProficiencies[x] 
-                    || game.packs.get("dnd5e.items").index.get(game.dnd5e.config.toolIds[x])?.name)
-                .concat(actor.data.data.traits.toolProf.custom.split(";")).filter(x => String(x) && x.length).join(", "),
-            "\nLanguages: ",
-            actor.data.data.traits.languages.value.map(x => game.dnd5e.config.languages[x])
-                .concat(actor.data.data.traits.languages.custom.split(";")).filter(x => String(x) && x.length).join(", ")
-        ].join("")
+    { "pdf": "CP", "foundry": @data.currency.cp || "" },
+    { "pdf": "ProficienciesLang", "foundry": (function() {
+            let s = "";
+            let a = actor.data.data.traits.weaponProf.value.map(x => game.dnd5e.config.weaponProficiencies[x]
+                || game.packs.get("dnd5e.items").index.get(game.dnd5e.config.weaponIds[x])?.name)
+                .concat(actor.data.data.traits.weaponProf.custom.split(";")).filter(x => String(x) && x.length);
+            if (a.length > 0) { s = `${s}Weapons: ${a.join(", ")}\n` }
+            a = actor.data.data.traits.armorProf.value.map(x => game.dnd5e.config.armorProficiencies[x]
+                || game.packs.get("dnd5e.items").index.get(game.dnd5e.config.armorIds[x])?.name)
+                .concat(actor.data.data.traits.armorProf.custom.split(";")).filter(x => String(x) && x.length);
+            if (a.length > 0) { s = `${s}Armor: ${a.join(", ")}\n` }
+            a = actor.data.data.traits.toolProf.value.map(x => game.dnd5e.config.toolProficiencies[x]
+                || game.packs.get("dnd5e.items").index.get(game.dnd5e.config.toolIds[x])?.name)
+                .concat(actor.data.data.traits.toolProf.custom.split(";")).filter(x => String(x) && x.length);
+            if (a.length > 0) { s = `${s}Tools: ${a.join(", ")}\n` }
+            a = actor.data.data.traits.languages.value.map(x => game.dnd5e.config.languages[x])
+                .concat(actor.data.data.traits.languages.custom.split(";")).filter(x => String(x) && x.length);
+            if (a.length > 0) { s = `${s}Languages: ${a.join(", ")}\n` }
+            return s
+        })()
     },
     { "pdf": "SP", "foundry": @data.currency.sp || "" },
     { "pdf": "EP", "foundry": @data.currency.ep || "" },
@@ -138,7 +139,7 @@
     { "pdf": "Faction Symbol Image", "foundry": "" }, /* Images are not supported */
     { "pdf": "Allies", "foundry": "" }, /* There is no field for this on the Foundry character sheet */
     { "pdf": "FactionName", "foundry": "" }, /* There is no field for this on the Foundry character sheet */
-    { "pdf": "Backstory", "foundry": @data.details.biography.value?.replaceAll(/<[^>]*>/g, "").replaceAll(/&[^;];/g, "").trim() },
+    { "pdf": "Backstory", "foundry": (function(h) {let d = document.createElement("div"); d.innerHTML = h; return d.textContent || d.innerText || "" })(@data.details.biography.value) },
     { "pdf": "Feat+Traits", "foundry": @items.filter(i => ['feat', 'trait'].includes(i.type)).slice(16).map(i => `${i.name} - ${i.data.data.source}`).join('\n') },
     { "pdf": "Treasure", "foundry": @items.filter(i => ['backpack', 'consumable', 'loot'].includes(i.type)).map(i => (i.data.data.quantity <= 1) ? i.name : `${i.name} (${i.data.data.quantity})`).join(', ') },
 

--- a/mappings/dnd5e.mapping
+++ b/mappings/dnd5e.mapping
@@ -13,7 +13,17 @@
     { "pdf": "ProfBonus", "foundry": @data.attributes.prof },
     { "pdf": "AC", "foundry": @data.attributes.ac.value },
     { "pdf": "Initiative", "foundry": @data.attributes.init.total },
-    { "pdf": "Speed", "foundry": Object.entries(@data.attributes.movement).filter(val => val[1]).map(val => val[0] === "hover" ? Object.entries(@data.attributes.movement)[6][0] : "" + val[0] !== "units" && val[0] !== "hover" ? val.join(": ") + Object.entries(@data.attributes.movement)[5][1] : "").filter(String).join(", ") },
+    { "pdf": "Speed", "foundry":
+        (function() {
+            const mo = actor.data.data.attributes.movement;
+            let mt = Object.entries(game.dnd5e.config.movementTypes).map(e => e[0]);
+            let ma = Object.entries(mo).filter(e => e[1] && mt.includes(e[0]));
+            if (mo.walk && ma.length === 1) {
+                return `${ma[0][1]}${mo.units}${mo.hover ? "\n(hover)" : ""}`
+            } else {
+                return ma.map(m => `${m[0].substring(0,2)}:${m[1]}${mo.units}`).join('\n').concat(mo.hover ? "\n(hover)" : "")
+            }
+        })() },
     { "pdf": "PersonalityTraits", "foundry": (function(h) { let d = document.createElement("div"); d.innerHTML = h; return d.textContent || d.innerText || ""; })(@data.details.trait) },
     { "pdf": "STRmod", "foundry": @data.abilities.str.mod },
     { "pdf": "ST Strength", "foundry": @data.abilities.str.save },

--- a/mappings/dnd5e.mapping
+++ b/mappings/dnd5e.mapping
@@ -19,9 +19,9 @@
             let mt = Object.entries(game.dnd5e.config.movementTypes).map(e => e[0]);
             let ma = Object.entries(mo).filter(e => e[1] && mt.includes(e[0]));
             if (mo.walk && ma.length === 1) {
-                return `${ma[0][1]}${mo.units}${mo.hover ? "\n(hover)" : ""}`
+                return `${ma[0][1]}${mo.units}${mo.hover ? "\n(hover)" : ""}`;
             } else {
-                return ma.map(m => `${m[0].substring(0,2)}:${m[1]}${mo.units}`).join('\n').concat(mo.hover ? "\n(hover)" : "")
+                return ma.map(m => `${m[0].substring(0,2)}:${m[1]}${mo.units}`).join('\n').concat(mo.hover ? "\n(hover)" : "");
             }
         })() },
     { "pdf": "PersonalityTraits", "foundry": (function(h) { let d = document.createElement("div"); d.innerHTML = h; return d.textContent || d.innerText || ""; })(@data.details.trait) },
@@ -127,7 +127,7 @@
             a = @data.traits.languages.value.map(x => game.dnd5e.config.languages[x])
                 .concat(@data.traits.languages.custom.split(";")).filter(x => String(x) && x.length);
             if (a.length > 0) { s = `${s}Languages: ${a.join(", ")}\n` }
-            return s
+            return s;
         })()
     },
     { "pdf": "SP", "foundry": @data.currency.sp || "" },


### PR DESCRIPTION
- translate and organize proficiencies, respect semicolon in custom lists (#20)
- use derivedDamage strings in attacks (#19)
- strip html chars from personality traits, ideals, bonds, and flaws (compatibility with tidy5e)
- include to-hit bonus in attacks
- star indicates additional damage from attack (more than one damage part)
- equipment sheet includes only weapons, equipment, and tools; containers and consumables moved to treasure for space management
- spells removed from equipment list