### PR TITLE
Export Text from the Description Field of Feats and Traits

### DIFF
--- a/mappings/dnd5e.mapping
+++ b/mappings/dnd5e.mapping
@@ -167,7 +167,12 @@
     { "pdf": "GP", "foundry": @data.currency.gp || "" },
     { "pdf": "PP", "foundry": @data.currency.pp || "" },   
     { "pdf": "Equipment", "foundry": @items.filter(i => ['weapon', 'equipment', 'tool'].includes(i.type)).map(i => (i.data.data.quantity <= 1) ? i.name : `${i.name} (${i.data.data.quantity})`).join(', ') },
-    { "pdf": "Features and Traits", "foundry": @items.filter(i => ['feat', 'trait'].includes(i.type)).slice(0, 16).map(i => `${i.name} - ${i.data.data.source}`).join('\n') },
+    { "pdf": "Features and Traits", "foundry": @items.filter(i => ["feat", "trait"].includes(i.type)).slice(0, 16).map(i => `${i.name} - ${i.data.data.source}: \n${((h) => {
+	   const d = document.createElement("div");
+	   d.innerHTML = h;
+	   return d.textContent || d.innerText || "";
+       })(i.data.data.description.value)}\n`).join("\n")
+		},
 
     /* Page #2 */
 


### PR DESCRIPTION
Request for optional description of Feats and Traits. 
With this code snippet all the Description-Field Text in Foundrys "Descrption"-Field of Feats will be displayed and "printed" to the Exported PDF

Maybe a Toggle-Option would be nice and/or to have certain Keywords or a kind of markdown for specific areas of the Descrition-Field, so that only a shorter, customized Text will be displayed insted of the whole text in the Description-Field. 
The idea of short explanations for skills and feats is inspired of the fastcharacter creation website. The sheet is very compact and there is a lot of info paked in it.

Furthermore it would be nice to make an export template for a similar design of that from fastcharacter.com.