### PR TITLE
Minimize text option

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -4,6 +4,10 @@
       "mapping": {
         "Name": "Mapping",
         "Hint": "JSON which is used to map the PDF fields to information on the Foundry character sheet. See the README for details."
+      },
+      "minimizeText": {
+        "Name": "Minimize text",
+        "Hint": "Write less text where possible."
       }
     },
     "download": {

--- a/scripts/pdfsheet.js
+++ b/scripts/pdfsheet.js
@@ -11,6 +11,15 @@ Hooks.on("init", () => {
 		default: "[]",
 	});
 
+	game.settings.register(Pdfconfig.ID, 'minimizeText', {
+		name: "pdfsheet.settings.minimizeText.Name",
+		hint: "pdfsheet.settings.minimizeText.Hint",
+		scope: 'client',
+		type: Boolean,
+		config: true,
+		default: false
+	});
+
 	if (game.version && isNewerVersion(game.version, "9.230")) {
 		game.keybindings.register(Pdfconfig.ID, "showConfig", {
 			name: "Show Config",


### PR DESCRIPTION
Added a setting for optional minimize text for mappings.

The goal is to make an option that you can access in a mapping file to choose what type of text to print.

Example of a mapping code:
```javascript
const minimizeText = game.settings.get(Pdfconfig.ID, 'minimizeText');
if (minimizeText) {
  // Do X
} else {
  // Do Y
}
```