### PR TITLE
Minimize features traits with the option

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -4,6 +4,10 @@
       "mapping": {
         "Name": "Mapping",
         "Hint": "JSON which is used to map the PDF fields to information on the Foundry character sheet. See the README for details."
+      },
+      "minimizeText": {
+        "Name": "Minimize text",
+        "Hint": "Write less text where possible."
       }
     },
     "download": {

--- a/mappings/dnd5e.mapping
+++ b/mappings/dnd5e.mapping
@@ -165,14 +165,18 @@
     { "pdf": "SP", "foundry": @data.currency.sp || "" },
     { "pdf": "EP", "foundry": @data.currency.ep || "" },
     { "pdf": "GP", "foundry": @data.currency.gp || "" },
-    { "pdf": "PP", "foundry": @data.currency.pp || "" },   
+    { "pdf": "PP", "foundry": @data.currency.pp || "" },
     { "pdf": "Equipment", "foundry": @items.filter(i => ['weapon', 'equipment', 'tool'].includes(i.type)).map(i => (i.data.data.quantity <= 1) ? i.name : `${i.name} (${i.data.data.quantity})`).join(', ') },
-    { "pdf": "Features and Traits", "foundry": @items.filter(i => ["feat", "trait"].includes(i.type)).slice(0, 16).map(i => `${i.name} - ${i.data.data.source}: \n${((h) => {
-	   const d = document.createElement("div");
-	   d.innerHTML = h;
-	   return d.textContent || d.innerText || "";
-       })(i.data.data.description.value)}\n`).join("\n")
-		},
+    { "pdf": "Features and Traits", "foundry": @items.filter(i => ["feat", "trait"].includes(i.type)).slice(0, 16).map(i => `${i.name} - ${i.data.data.source}${((h) => {
+            const minimizeText = game.settings.get(Pdfconfig.ID, 'minimizeText');
+            if (!minimizeText) {
+                const d = document.createElement("div");
+                d.innerHTML = h;
+                return ":\n" + (d.textContent || d.innerText || "") + "\n";
+            }
+            return "";
+        })(i.data.data.description.value)}`).join("\n")
+    },
 
     /* Page #2 */
 

--- a/scripts/pdfsheet.js
+++ b/scripts/pdfsheet.js
@@ -11,6 +11,15 @@ Hooks.on("init", () => {
 		default: "[]",
 	});
 
+	game.settings.register(Pdfconfig.ID, 'minimizeText', {
+		name: "pdfsheet.settings.minimizeText.Name",
+		hint: "pdfsheet.settings.minimizeText.Hint",
+		scope: 'client',
+		type: Boolean,
+		config: true,
+		default: false
+	});
+
 	if (game.version && isNewerVersion(game.version, "9.230")) {
 		game.keybindings.register(Pdfconfig.ID, "showConfig", {
 			name: "Show Config",


### PR DESCRIPTION
Based on #58 

Optionally minimize the output text for "Features & Traits" in dnd5e pdf.
The PDF box can only store 34 lines of text and a character usually have a lot of features/traits, thanks to this option you can choose to do not print the description of each object.

---

Output example:
```
First feature:
Description of the first feature

Second feature:
Description of the second feature

...
```
_(5+ lines for 2 features)_


Output example with minimize:
```
First feature
Second feature
```
_(2+ lines for 2 features)_